### PR TITLE
Change container image value key

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # authentik
 
-![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![AppVersion: 2021.5.4](https://img.shields.io/badge/AppVersion-2021.5.4-informational?style=flat-square)
+![Version: 2.0.0](https://img.shields.io/badge/Version-2.0.0-informational?style=flat-square) ![AppVersion: 2021.6.4](https://img.shields.io/badge/AppVersion-2021.6.4-informational?style=flat-square)
 
 authentik is an open-source Identity Provider focused on flexibility and versatility
 
@@ -95,7 +95,7 @@ redis:
 | geoip.image | string | `"maxmindinc/geoipupdate:v4.7"` |  |
 | geoip.licenseKey | string | `""` | sign up under https://www.maxmind.com/en/geolite2/signup |
 | geoip.updateInterval | int | `8` | number of hours between update runs |
-| image.name | string | `"ghcr.io/goauthentik/server"` |  |
+| image.repository | string | `"ghcr.io/goauthentik/server"` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.tag | string | `"2021.5.4"` |  |
 | ingress.annotations | object | `{}` |  |

--- a/charts/authentik/Chart.yaml
+++ b/charts/authentik/Chart.yaml
@@ -16,8 +16,8 @@ keywords:
   - ldap
   - idp
   - sp
-version: 1.1.0
-appVersion: 2021.5.4
+version: 2.0.0
+appVersion: 2021.6.4
 icon: https://raw.githubusercontent.com/BeryJu/authentik/master/web/icons/icon.svg
 maintainers:
   - name: BeryJu
@@ -40,8 +40,10 @@ dependencies:
     version: 2.4.0
 annotations:
   artifacthub.io/changes: |
-    - kind: added
-      description: migrate GeoIP from CronJob to sidecar with emptyDir
+    - kind: changed
+      description: Breaking: Image value key is now repository
+    - kind: changed
+      description: App version update to 2021.6.4
   artifacthub.io/license: GPL-3.0-only
   artifacthub.io/links: |
     - name: Github

--- a/charts/authentik/README.md
+++ b/charts/authentik/README.md
@@ -1,6 +1,6 @@
 # authentik
 
-![Version: 1.1.0](https://img.shields.io/badge/Version-1.1.0-informational?style=flat-square) ![AppVersion: 2021.5.4](https://img.shields.io/badge/AppVersion-2021.5.4-informational?style=flat-square)
+![Version: 2.0.0](https://img.shields.io/badge/Version-2.0.0-informational?style=flat-square) ![AppVersion: 2021.6.4](https://img.shields.io/badge/AppVersion-2021.6.4-informational?style=flat-square)
 
 authentik is an open-source Identity Provider focused on flexibility and versatility
 
@@ -95,7 +95,7 @@ redis:
 | geoip.image | string | `"maxmindinc/geoipupdate:v4.7"` |  |
 | geoip.licenseKey | string | `""` | sign up under https://www.maxmind.com/en/geolite2/signup |
 | geoip.updateInterval | int | `8` | number of hours between update runs |
-| image.name | string | `"ghcr.io/goauthentik/server"` |  |
+| image.repository | string | `"ghcr.io/goauthentik/server"` |  |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.tag | string | `"2021.5.4"` |  |
 | ingress.annotations | object | `{}` |  |

--- a/charts/authentik/ci/ct-values.yaml
+++ b/charts/authentik/ci/ct-values.yaml
@@ -4,7 +4,7 @@ worker:
   replicas: 1
 
 image:
-  name: ghcr.io/goauthentik/server
+  repository: ghcr.io/goauthentik/server
   tag: 2021.5.4
   pullPolicy: IfNotPresent
 

--- a/charts/authentik/templates/deployment.yaml
+++ b/charts/authentik/templates/deployment.yaml
@@ -51,7 +51,7 @@ spec:
               mountPath: /usr/share/GeoIP
       {{- end }}
         - name: {{ $.Chart.Name }}
-          image: "{{ $.Values.image.name }}:{{ $.Values.image.tag }}"
+          image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag }}"
           imagePullPolicy: "{{ $.Values.image.pullPolicy }}"
           args: [{{ quote . }}]
           env:

--- a/charts/authentik/values.yaml
+++ b/charts/authentik/values.yaml
@@ -6,8 +6,8 @@ worker:
   replicas: 1
 
 image:
-  name: ghcr.io/goauthentik/server
-  tag: 2021.5.4
+  repository: ghcr.io/goauthentik/server
+  tag: 2021.6.4
   pullPolicy: IfNotPresent
 
 ingress:


### PR DESCRIPTION
Change the value key for the image from `name` to `repository`, which is a best practise and allows Renovate bot to track updates using the default helm-values manager: https://docs.renovatebot.com/modules/manager/helm-values/