### PR TITLE
Quote any env variables provided to the chart

### DIFF
--- a/charts/authentik/Chart.yaml
+++ b/charts/authentik/Chart.yaml
@@ -16,7 +16,7 @@ keywords:
   - ldap
   - idp
   - sp
-version: 5.2.1
+version: 5.2.2
 appVersion: 2021.12.5
 icon: https://raw.githubusercontent.com/BeryJu/authentik/master/web/icons/icon.svg
 maintainers:

--- a/charts/authentik/templates/_helpers.tpl
+++ b/charts/authentik/templates/_helpers.tpl
@@ -16,10 +16,12 @@
       {{- $value := $v -}}
       {{- if or (kindIs "bool" $v) (kindIs "float64" $v) -}}
         {{- $v = quote $v -}}
+      {{- else -}}
+        {{- $v = tpl $v $.root | quote }}
       {{- end -}}
       {{- if $v }}
 - name: {{ printf "AUTHENTIK_%s" (upper $k) }}
-  value: {{ tpl $v $.root }}
+  value: {{ $v }}
       {{- end }}
     {{- end -}}
   {{- end -}}


### PR DESCRIPTION
if for example, your password starts with &, yaml gets super confused (probably due to it thinking its a anchor)