### PR TITLE
Use secrets instead of plain text env variables

### DIFF
--- a/charts/authentik/templates/_helpers.tpl
+++ b/charts/authentik/templates/_helpers.tpl
@@ -26,3 +26,23 @@
     {{- end -}}
   {{- end -}}
 {{- end -}}
+
+{{- define "authentik.secret" -}}
+  {{- range $k, $v := .values -}}
+    {{- if kindIs "map" $v -}}
+      {{- range $sk, $sv := $v -}}
+        {{- include "authentik.secret" (dict "root" $.root "values" (dict (printf "%s__%s" (upper $k) (upper $sk)) $sv)) -}}
+      {{- end -}}
+    {{- else -}}
+      {{- $value := $v -}}
+      {{- if or (kindIs "bool" $v) (kindIs "float64" $v) -}}
+        {{- $v = toString $v -}}
+      {{- else -}}
+        {{- $v = tpl $v $.root }}
+      {{- end -}}
+      {{- if $v }}
+{{ printf "AUTHENTIK_%s" (upper $k) }}: {{ $v | b64enc | quote }}
+      {{- end }}
+    {{- end -}}
+  {{- end -}}
+{{- end -}}

--- a/charts/authentik/templates/deployment.yaml
+++ b/charts/authentik/templates/deployment.yaml
@@ -1,3 +1,9 @@
+{{- $env := .Values.env }}
+{{- range $name, $val := $.Values.envValueFrom }}
+{{- $env = merge $env (dict "name" $name "valueFrom" (toYaml $val)) }}
+{{- end }}
+{{- $envFrom := .Values.envFrom }}
+{{- $envFrom := append $envFrom (dict "secretRef" (dict "name" (printf "%s-secrets" (include "common.names.fullname" .) ))) }}
 {{- range list "server" "worker" }}
 ---
 apiVersion: apps/v1
@@ -57,18 +63,14 @@ spec:
           image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag }}"
           imagePullPolicy: "{{ $.Values.image.pullPolicy }}"
           args: [{{ quote . }}]
+            {{- with $env }}
           env:
-            {{- range $k, $v := $.Values.env }}
+            {{- range $k, $v := . }}
             - name: {{ quote $k }}
               value: {{ quote $v }}
             {{- end }}
-            {{- include "authentik.env" (dict "root" $ "values" $.Values.authentik) | indent 12 }}
-            {{- range $name, $val := $.Values.envValueFrom }}
-            - name: {{ $name }}
-              valueFrom:
-                {{- toYaml $val | nindent 16 }}
             {{- end }}
-            {{- with $.Values.envFrom }}
+            {{- with $envFrom }}
           envFrom:
               {{- toYaml . | nindent 12 }}
             {{- end }}
@@ -110,16 +112,25 @@ spec:
         - name: geoip-sidecar
           image: "{{ $.Values.geoip.image }}"
           env:
+{{- range $name, $val := $.Values.envValueFrom }}
+{{- $env = merge $env (dict "name" $name "valueFrom" (toYaml $val)) }}
+{{- end }}
             - name: GEOIPUPDATE_FREQUENCY
               value: {{ $.Values.geoip.updateInterval | quote }}
             - name: GEOIPUPDATE_PRESERVE_FILE_TIMES
               value: "1"
-            - name: GEOIPUPDATE_ACCOUNT_ID
-              value: {{ required "geoip account id required" $.Values.geoip.accountId | quote }}
-            - name: GEOIPUPDATE_LICENSE_KEY
-              value: {{ required "geoip license key required" $.Values.geoip.licenseKey | quote }}
             - name: GEOIPUPDATE_EDITION_IDS
               value: {{ required "geoip edition id required" $.Values.geoip.editionIds | quote }}
+            - name: GEOIPUPDATE_ACCOUNT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ printf "%s-secrets" (include "common.names.fullname" $) }}
+                  key: GEOIPUPDATE_ACCOUNT_ID
+            - name: GEOIPUPDATE_LICENSE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ printf "%s-secrets" (include "common.names.fullname" $) }}
+                  key: GEOIPUPDATE_LICENSE_KEY
           volumeMounts:
             - name: geoip-db
               mountPath: /usr/share/GeoIP

--- a/charts/authentik/templates/secret.yml
+++ b/charts/authentik/templates/secret.yml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ printf "%s-secrets" (include "common.names.fullname" .) }}
+  labels:
+    {{- include "common.labels" . | nindent 4 }}
+type: Opaque
+data:
+  {{- include "authentik.secret" (dict "root" . "values" .Values.authentik) | indent 2 }}
+  {{- if $.Values.geoip.enabled }}
+  GEOIPUPDATE_ACCOUNT_ID: {{ required "geoip account id required" .Values.geoip.accountId | toString | b64enc | quote }}
+  GEOIPUPDATE_LICENSE_KEY: {{ required "geoip license key required" .Values.geoip.licenseKey | toString | b64enc | quote }}
+  {{- end }}


### PR DESCRIPTION
I use helm-secrets to encode secrets then have it deployed via CI. Helm's output will encode secrets as ++, but regular env variables get the full string.

This PR moves all the generated env variables to secrets (anything in values from env: and envFrom: are kept as env). from testing locally it seems to work smoothly