### PR TITLE
Adds configuration for automated install of authentik

### DIFF
--- a/charts/authentik/README.md
+++ b/charts/authentik/README.md
@@ -96,6 +96,9 @@ redis:
 | authentik.redis.host | string | `{{ .Release.Name }}-redis-master` | set the redis hostname to talk to |
 | authentik.redis.password | string | `""` |  |
 | authentik.secret_key | string | `""` | Secret key used for cookie singing and unique user IDs, don't change this after the first install |
+| authentik.automatedInstall.existingSecret.secretName | string | `""` | Name of an existing secret key used for the configuration of the automated install https://goauthentik.io/docs/installation/automated-install |
+| authentik.automatedInstall.existingSecret.passwordKey | string | `"AK_ADMIN_PASS"` | Key for the retrieval of the password for akadmin |
+| authentik.automatedInstall.existingSecret.tokenKey | string | `"AK_ADMIN_TOKEN"` | Key for the retrieval of the token for akadmin |
 | env | object | `{}` | see configuration options at https://goauthentik.io/docs/installation/configuration/ |
 | envFrom | list | `[]` |  |
 | envValueFrom | object | `{}` |  |

--- a/charts/authentik/templates/deployment.yaml
+++ b/charts/authentik/templates/deployment.yaml
@@ -71,6 +71,18 @@ spec:
             - name: {{ quote $k }}
               value: {{ quote $v }}
             {{- end }}
+            {{- if $.Values.authentik.automatedInstall.existingSecret }}
+            - name: AK_ADMIN_PASS
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $.Values.authentik.automatedInstall.existingSecret.secretName | default (printf "%s-%s" $.Release.Name "automated-install") }}
+                  key: {{ $.Values.authentik.automatedInstall.existingSecret.passwordKey | default "AK_ADMIN_PASS" }}
+            - name: AK_ADMIN_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ $.Values.authentik.automatedInstall.existingSecret.secretName | default (printf "%s-%s" $.Release.Name "automated-install") }}
+                  key: {{ $.Values.authentik.automatedInstall.existingSecret.tokenKey | default "AK_ADMIN_TOKEN" }}
+            {{- end }}
             {{- include "authentik.env" (dict "root" $ "values" $.Values.authentik) | indent 12 }}
             {{- range $name, $val := $.Values.envValueFrom }}
             - name: {{ $name }}

--- a/charts/authentik/values.yaml
+++ b/charts/authentik/values.yaml
@@ -113,6 +113,10 @@ authentik:
     # @default -- `{{ .Release.Name }}-redis-master`
     host: '{{ .Release.Name }}-redis-master'
     password: ""
+  # -- configuration for automated install: https://goauthentik.io/docs/installation/automated-install
+  automatedInstall:
+    existingSecret:
+      secretName: ""
 
 # -- see configuration options at https://goauthentik.io/docs/installation/configuration/
 env: {}


### PR DESCRIPTION
Adds configuration options for automated install of Authentik for helm installs.
Using the env configurations did not work out for me, as these were prefixed in the templates and I think it makes sense to have the options more prominently.