### PR TITLE
Fix envValueFrom templating

### DIFF
--- a/charts/authentik/templates/_helpers.tpl
+++ b/charts/authentik/templates/_helpers.tpl
@@ -7,24 +7,15 @@
 {{- end -}}
 
 {{- define "authentik.env" -}}
-  {{- range $k, $v := .values -}}
-    {{- if kindIs "map" $v -}}
-      {{- range $sk, $sv := $v -}}
-        {{- include "authentik.env" (dict "root" $.root "values" (dict (printf "%s__%s" (upper $k) (upper $sk)) $sv)) -}}
-      {{- end -}}
-    {{- else -}}
-      {{- $value := $v -}}
-      {{- if or (kindIs "bool" $v) (kindIs "float64" $v) -}}
-        {{- $v = quote $v -}}
-      {{- else -}}
-        {{- $v = tpl $v $.root | quote }}
-      {{- end -}}
-      {{- if and ($v) (ne $v "\"\"") }}
-- name: {{ printf "AUTHENTIK_%s" (upper $k) }}
-  value: {{ $v }}
-      {{- end }}
-    {{- end -}}
-  {{- end -}}
+{{- range $name, $val := .Values.env }}
+  - name: {{ $name }}
+    value: {{ $val }}
+{{- end }}
+{{- range $name, $val := .Values.envValueFrom }}
+  - name: {{ $name }}
+    valueFrom:
+      {{- toYaml $val | nindent 6 }}
+{{- end }}
 {{- end -}}
 
 {{- define "authentik.secret" -}}

--- a/charts/authentik/templates/deployment.yaml
+++ b/charts/authentik/templates/deployment.yaml
@@ -1,9 +1,3 @@
-{{- $env := .Values.env }}
-{{- range $name, $val := $.Values.envValueFrom }}
-{{- $env = merge $env (dict "name" $name "valueFrom" (toYaml $val)) }}
-{{- end }}
-{{- $envFrom := .Values.envFrom }}
-{{- $envFrom := append $envFrom (dict "secretRef" (dict "name" (printf "%s-secrets" (include "common.names.fullname" .) ))) }}
 {{- range list "server" "worker" }}
 ---
 apiVersion: apps/v1
@@ -76,17 +70,14 @@ spec:
           image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag }}"
           imagePullPolicy: "{{ $.Values.image.pullPolicy }}"
           args: [{{ quote . }}]
-            {{- with $env }}
           env:
-            {{- range $k, $v := . }}
-            - name: {{ quote $k }}
-              value: {{ quote $v }}
-            {{- end }}
-            {{- end }}
-            {{- with $envFrom }}
+            {{- include "authentik.env" $ | indent 12 }}
           envFrom:
-              {{- toYaml . | nindent 12 }}
+            {{- with $.Values.envFrom }}
+            {{- toYaml . | nindent 12 }}
             {{- end }}
+            - secretRef:
+                name: {{ include "common.names.fullname" $ }}-secrets
           volumeMounts:
             - name: geoip-db
               mountPath: /geoip
@@ -133,9 +124,6 @@ spec:
         - name: geoip-sidecar
           image: "{{ $.Values.geoip.image }}"
           env:
-{{- range $name, $val := $.Values.envValueFrom }}
-{{- $env = merge $env (dict "name" $name "valueFrom" (toYaml $val)) }}
-{{- end }}
             - name: GEOIPUPDATE_FREQUENCY
               value: {{ $.Values.geoip.updateInterval | quote }}
             - name: GEOIPUPDATE_PRESERVE_FILE_TIMES


### PR DESCRIPTION
This PR fixes #85 by moving `.Values.env` and `.Values.envValueFrom` logic back into the `authentik.env` helper. I was able to simplify the helper to match the recent env changes.

Let me know if you were intending to get rid of the helper completely or have any suggestions. I'd be open to changing this as needed!

Thank you for all the work you do! I'm a big fan of Authentik.