### PR TITLE
Add optional container image digest

### DIFF
--- a/charts/authentik/Chart.yaml
+++ b/charts/authentik/Chart.yaml
@@ -16,7 +16,7 @@ keywords:
   - ldap
   - idp
   - sp
-version: 2022.8.3
+version: 2022.9.0
 appVersion: 2022.8.2
 icon: https://raw.githubusercontent.com/BeryJu/authentik/master/web/icons/icon.svg
 maintainers:

--- a/charts/authentik/Chart.yaml
+++ b/charts/authentik/Chart.yaml
@@ -16,7 +16,7 @@ keywords:
   - ldap
   - idp
   - sp
-version: 2022.9.0
+version: 2022.8.3
 appVersion: 2022.8.2
 icon: https://raw.githubusercontent.com/BeryJu/authentik/master/web/icons/icon.svg
 maintainers:

--- a/charts/authentik/README.md
+++ b/charts/authentik/README.md
@@ -110,6 +110,7 @@ redis:
 | image.pullSecrets | list | `[]` |  |
 | image.repository | string | `"ghcr.io/goauthentik/server"` |  |
 | image.tag | string | `"2022.8.2"` |  |
+| image.digest | string | `nil` | optional container image digest |
 | ingress.annotations | object | `{}` |  |
 | ingress.enabled | bool | `false` |  |
 | ingress.hosts[0].host | string | `"authentik.domain.tld"` |  |

--- a/charts/authentik/templates/deployment.yaml
+++ b/charts/authentik/templates/deployment.yaml
@@ -67,7 +67,7 @@ spec:
       {{- end }}
       containers:
         - name: {{ $.Chart.Name }}
-          image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag }}"
+          image: "{{ $.Values.image.repository }}:{{ $.Values.image.tag }}{{- if $.Values.image.digest -}}@{{ $.Values.image.digest }}{{- end -}}"
           imagePullPolicy: "{{ $.Values.image.pullPolicy }}"
           args: [{{ quote . }}]
           env:

--- a/charts/authentik/values.yaml
+++ b/charts/authentik/values.yaml
@@ -16,6 +16,7 @@ worker:
 image:
   repository: ghcr.io/goauthentik/server
   tag: 2022.8.2
+  digest:
   pullPolicy: IfNotPresent
   pullSecrets: []
 


### PR DESCRIPTION
Specifying the digest in `image.tag` does not work as the tag is used to set version labels and K8s has a length limit on those (and it would not be a good label even if K8s didn't). Didn't specify current version digest in `values.yaml`, as it would break backward compatibility and force some users to unset it explicitly.