### PR TITLE
Add support for container securityContext

### DIFF
--- a/charts/authentik/README.md
+++ b/charts/authentik/README.md
@@ -106,6 +106,7 @@ redis:
 | geoip.image | string | `"maxmindinc/geoipupdate:v4.8"` |  |
 | geoip.licenseKey | string | `""` | sign up under https://www.maxmind.com/en/geolite2/signup |
 | geoip.updateInterval | int | `8` | number of hours between update runs |
+| geoip.containerSecurityContext | object | `{}` | geoip containerSecurityContext |
 | image.digest | string | `""` | optional container image digest |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.pullSecrets | list | `[]` |  |
@@ -151,6 +152,7 @@ redis:
 | resources.server | object | `{}` |  |
 | resources.worker | object | `{}` |  |
 | securityContext | object | `{}` | server securityContext |
+| containerSecurityContext | object | `{}` | server containerSecurityContext |
 | service.annotations | object | `{}` |  |
 | service.enabled | bool | `true` | Service that is created to access authentik |
 | service.labels | object | `{}` |  |
@@ -172,3 +174,4 @@ redis:
 | worker.priorityClassName | string | `nil` | Custom priority class for different treatment by the scheduler |
 | worker.replicas | int | `1` | worker replicas |
 | worker.securityContext | object | `{}` | worker securityContext |
+| worker.containerSecurityContext | object | `{}` | worker containerSecurityContext |

--- a/charts/authentik/templates/server-deployment.yaml
+++ b/charts/authentik/templates/server-deployment.yaml
@@ -125,6 +125,8 @@ spec:
           resources:
               {{- toYaml . | nindent 12 }}
             {{- end }}
+          securityContext:
+            {{- toYaml $.Values.containerSecurityContext | nindent 12 }}
       {{- if $.Values.geoip.enabled }}
         - name: geoip-sidecar
           image: "{{ $.Values.geoip.image }}"
@@ -148,6 +150,8 @@ spec:
           volumeMounts:
             - name: geoip-db
               mountPath: /usr/share/GeoIP
+          securityContext:
+            {{- toYaml $.Values.geoip.containerSecurityContext | nindent 12 }}
       {{- end }}
       {{- with $.Values.additionalContainers }}
         {{- $additionalContainers := list }}

--- a/charts/authentik/templates/worker-deployment.yaml
+++ b/charts/authentik/templates/worker-deployment.yaml
@@ -106,6 +106,8 @@ spec:
           resources:
               {{- toYaml . | nindent 12 }}
             {{- end }}
+          securityContext:
+            {{- toYaml $.Values.worker.containerSecurityContext | nindent 12 }}
       {{- if $.Values.geoip.enabled }}
         - name: geoip-sidecar
           image: "{{ $.Values.geoip.image }}"
@@ -129,6 +131,8 @@ spec:
           volumeMounts:
             - name: geoip-db
               mountPath: /usr/share/GeoIP
+          securityContext:
+            {{- toYaml $.Values.geoip.containerSecurityContext | nindent 12 }}
       {{- end }}
       {{- with $.Values.additionalContainers }}
         {{- $additionalContainers := list }}

--- a/charts/authentik/values.yaml
+++ b/charts/authentik/values.yaml
@@ -4,6 +4,8 @@ replicas: 1
 priorityClassName:
 # -- server securityContext
 securityContext: {}
+# -- server containerSecurityContext
+containerSecurityContext: {}
 
 worker:
   # -- worker replicas
@@ -12,6 +14,8 @@ worker:
   priorityClassName:
   # -- worker securityContext
   securityContext: {}
+  # -- server containerSecurityContext
+  containerSecurityContext: {}
 
 image:
   repository: ghcr.io/goauthentik/server
@@ -220,7 +224,8 @@ geoip:
   image: maxmindinc/geoipupdate:v4.8
   # -- number of hours between update runs
   updateInterval: 8
-
+  # -- server containerSecurityContext
+  containerSecurityContext: {}
 postgresql:
   # -- enable the bundled bitnami postgresql chart
   enabled: false


### PR DESCRIPTION
This allows setting securityContext within a container.
Although most settings can be done at the pod level, a few cannot, such as `allowPrivilegeEscalation` and `capabilities`, both settings which are required if running with pod  security set to [restricted](https://kubernetes.io/docs/concepts/security/pod-security-admission/#pod-security-levels).