### PR TITLE
setting up secretname for geoip account/license ids

### DIFF
--- a/charts/authentik/templates/deployment.yaml
+++ b/charts/authentik/templates/deployment.yaml
@@ -135,10 +135,23 @@ spec:
               value: {{ $.Values.geoip.updateInterval | quote }}
             - name: GEOIPUPDATE_PRESERVE_FILE_TIMES
               value: "1"
+            {{- if $.Values.geoip.secretName }}
+            - name: GEOIPUPDATE_ACCOUNT_ID
+              valueFrom:
+                secretKeyRef:
+                  name: {{ required "geoip secret name or plaintext values required" $.Values.geoip.secretName | quote }}
+                  key: accountId
+            - name: GEOIPUPDATE_LICENSE_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: {{ required "geoip secret name or plaintext values required" $.Values.geoip.secretName | quote }}
+                  key: licenseKey
+            {{ else }}
             - name: GEOIPUPDATE_ACCOUNT_ID
               value: {{ required "geoip account id required" $.Values.geoip.accountId | quote }}
             - name: GEOIPUPDATE_LICENSE_KEY
               value: {{ required "geoip license key required" $.Values.geoip.licenseKey | quote }}
+            {{ end }}
             - name: GEOIPUPDATE_EDITION_IDS
               value: {{ required "geoip edition id required" $.Values.geoip.editionIds | quote }}
           volumeMounts:

--- a/charts/authentik/values.yaml
+++ b/charts/authentik/values.yaml
@@ -193,11 +193,13 @@ prometheus:
 
 geoip:
   # -- optional GeoIP, deploys a cronjob to download the maxmind database
+  # -- sign up under https://www.maxmind.com/en/geolite2/signup
   enabled: false
-  # -- sign up under https://www.maxmind.com/en/geolite2/signup
-  accountId: ""
-  # -- sign up under https://www.maxmind.com/en/geolite2/signup
-  licenseKey: ""
+  # -- secret name with the keys "accountId" and "licenseKey" instead of plaintext
+  secretName: null
+  # -- only use either secretName OR accountId/licenseKey
+  accountId: null
+  licenseKey: null
   editionIds: "GeoLite2-City"
   image: maxmindinc/geoipupdate:v4.8
   # -- number of hours between update runs


### PR DESCRIPTION
Moved some of the docs on how to register to the top of the section

Added a secretName structure so that the env can be set from either the secretName or the values directly

Trying to avoid doing secrets in Plaintext, so this is necessary to either use something like Vault+ESO, or to pre-generate the secret