### PR TITLE
Add secret token creation for k8s 1.24+

### DIFF
--- a/charts/authentik/Chart.yaml
+++ b/charts/authentik/Chart.yaml
@@ -16,8 +16,8 @@ keywords:
   - ldap
   - idp
   - sp
-version: 2022.11.0
-appVersion: 2022.11.0
+version: 2022.10.0
+appVersion: 2022.10.0
 icon: https://raw.githubusercontent.com/BeryJu/authentik/master/web/icons/icon.svg
 maintainers:
   - name: BeryJu

--- a/charts/authentik/Chart.yaml
+++ b/charts/authentik/Chart.yaml
@@ -16,8 +16,8 @@ keywords:
   - ldap
   - idp
   - sp
-version: 2022.10.0
-appVersion: 2022.10.0
+version: 2022.11.0
+appVersion: 2022.11.0
 icon: https://raw.githubusercontent.com/BeryJu/authentik/master/web/icons/icon.svg
 maintainers:
   - name: BeryJu

--- a/charts/authentik/templates/rbac.yaml
+++ b/charts/authentik/templates/rbac.yaml
@@ -6,6 +6,7 @@ metadata:
   name: {{ include "common.names.fullname" . }}
   namespace: {{ .Release.Namespace }}
 ---
+{{- if semverCompare ">= 1.24" .Capabilities.KubeVersion.Version }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -15,6 +16,7 @@ metadata:
     kubernetes.io/service-account.name: {{ include "common.names.fullname" . }}
 type: kubernetes.io/service-account-token
 ---
+{{- end }}
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/charts/authentik/templates/rbac.yaml
+++ b/charts/authentik/templates/rbac.yaml
@@ -6,6 +6,15 @@ metadata:
   name: {{ include "common.names.fullname" . }}
   namespace: {{ .Release.Namespace }}
 ---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "common.names.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    kubernetes.io/service-account.name: {{ include "common.names.fullname" . }}
+type: kubernetes.io/service-account-token
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:


### PR DESCRIPTION
As of k8s 1.24 there is no automatic secret token creation for service accounts. This is adding the token creation so that it doesn't have to be done manually to allow Authentik to create outposts in the cluster.