### PR TITLE
Fix invalid targetPort assignment

### DIFF
--- a/charts/authentik/templates/service.yaml
+++ b/charts/authentik/templates/service.yaml
@@ -47,7 +47,7 @@ spec:
       protocol: TCP
       targetPort: http-metrics
     - port: {{ .Values.service.port }}
-      targetPort: {{ .Values.service.name }}
+      targetPort: http
       protocol: {{ .Values.service.protocol }}
       name: {{ .Values.service.name }}
       {{- if and (eq $type "NodePort") .Values.service.nodePort }}


### PR DESCRIPTION
When assigning a service name via the `service.name` value it should not change the `targetPort`.
The name `http` is hardcoded in the deployment so any change to that value causes port binding to fail.

This fixes the issue by no longer dynamically assigning the `targetPort`.