### PR TITLE
Pass labels from values file to ingress / services

### DIFF
--- a/charts/authentik/templates/ingress.yaml
+++ b/charts/authentik/templates/ingress.yaml
@@ -6,6 +6,9 @@ metadata:
   name: {{ include "common.names.fullname" . }}
   labels:
     {{- include "common.labels" . | nindent 4 }}
+    {{- with .Values.ingress.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
   {{- with .Values.ingress.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/charts/authentik/templates/service.yaml
+++ b/charts/authentik/templates/service.yaml
@@ -4,6 +4,9 @@ metadata:
   name: {{ include "common.names.fullname" . }}
   labels:
   {{- include "common.labels" . | nindent 4 }}
+  {{- with .Values.service.labels }}
+  {{- toYaml . | nindent 4 }}
+  {{- end }}
   {{- with .Values.service.annotations }}
   annotations:
   {{ toYaml . | nindent 4 }}


### PR DESCRIPTION
Hi,

the labels from `ingress.labels` and `service.labels` have not been passed from values file to the generated config. This PR just adds the missing lines to the template.

Cheers,
      Chris

