### PR TITLE
remote-cluster: add ServiceAccount secret for 1.24+

### DIFF
--- a/charts/authentik-remote-cluster/Chart.yaml
+++ b/charts/authentik-remote-cluster/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-version: 1.1.0
-appVersion: 2021.10.2
+version: 1.1.1
+appVersion: 2023.4.1
 name: authentik-remote-cluster
 description: RBAC required for a remote cluster to be connected to authentik.
 type: application

--- a/charts/authentik-remote-cluster/README.md
+++ b/charts/authentik-remote-cluster/README.md
@@ -30,3 +30,4 @@ RBAC required for a remote cluster to be connected to authentik.
 | annotations | object | `{}` |  |
 | fullnameOverride | string | `""` |  |
 | nameOverride | string | `""` |  |
+| serviceAccountSecret.enabled | bool | `true` |  |

--- a/charts/authentik-remote-cluster/templates/NOTES.txt
+++ b/charts/authentik-remote-cluster/templates/NOTES.txt
@@ -4,7 +4,7 @@ Run the commands below to get a kubeconfig file for authentik:
 KUBE_API=https://localhost:8443
 
 NAMESPACE={{ .Release.Namespace }}
-SECRET_NAME=$(kubectl get serviceaccount {{ include "authentik-remote-cluster.fullname" . }} -o jsonpath='{.secrets[0].name}')
+SECRET_NAME=$(kubectl get serviceaccount {{ include "authentik-remote-cluster.fullname" . }} -o jsonpath='{.secrets[0].name}' 2>/dev/null || echo -n "{{ include "authentik-remote-cluster.fullname" . }}")
 KUBE_CA=$(kubectl -n $NAMESPACE get secret/$SECRET_NAME -o jsonpath='{.data.ca\.crt}')
 KUBE_TOKEN=$(kubectl -n $NAMESPACE get secret/$SECRET_NAME -o jsonpath='{.data.token}' | base64 --decode)
 

--- a/charts/authentik-remote-cluster/templates/NOTES.txt
+++ b/charts/authentik-remote-cluster/templates/NOTES.txt
@@ -1,11 +1,12 @@
 Run the commands below to get a kubeconfig file for authentik:
 
-# your server name goes here
+# your kubeconfig's server endpoint goes here
 KUBE_API=https://localhost:8443
 
+NAMESPACE={{ .Release.Namespace }}
 SECRET_NAME=$(kubectl get serviceaccount {{ include "authentik-remote-cluster.fullname" . }} -o jsonpath='{.secrets[0].name}')
-KUBE_CA=$(kubectl get secret/$SECRET_NAME -o jsonpath='{.data.ca\.crt}')
-KUBE_TOKEN=$(kubectl get secret/$SECRET_NAME -o jsonpath='{.data.token}' | base64 --decode)
+KUBE_CA=$(kubectl -n $NAMESPACE get secret/$SECRET_NAME -o jsonpath='{.data.ca\.crt}')
+KUBE_TOKEN=$(kubectl -n $NAMESPACE get secret/$SECRET_NAME -o jsonpath='{.data.token}' | base64 --decode)
 
 echo "apiVersion: v1
 kind: Config
@@ -18,7 +19,7 @@ contexts:
 - name: default-context
   context:
     cluster: default-cluster
-    namespace: {{ .Release.Namespace }}
+    namespace: $NAMESPACE
     user: authentik-user
 current-context: default-context
 users:

--- a/charts/authentik-remote-cluster/templates/NOTES.txt
+++ b/charts/authentik-remote-cluster/templates/NOTES.txt
@@ -1,8 +1,6 @@
 Run the commands below to get a kubeconfig file for authentik:
 
-# your kubeconfig's server endpoint goes here
-KUBE_API=https://localhost:8443
-
+KUBE_API=$(kubectl config view --minify --output jsonpath="{.clusters[*].cluster.server}")
 NAMESPACE={{ .Release.Namespace }}
 SECRET_NAME=$(kubectl get serviceaccount {{ include "authentik-remote-cluster.fullname" . }} -o jsonpath='{.secrets[0].name}' 2>/dev/null || echo -n "{{ include "authentik-remote-cluster.fullname" . }}")
 KUBE_CA=$(kubectl -n $NAMESPACE get secret/$SECRET_NAME -o jsonpath='{.data.ca\.crt}')

--- a/charts/authentik-remote-cluster/templates/cluster-role-binding.yaml
+++ b/charts/authentik-remote-cluster/templates/cluster-role-binding.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:

--- a/charts/authentik-remote-cluster/templates/cluster-role.yaml
+++ b/charts/authentik-remote-cluster/templates/cluster-role.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/charts/authentik-remote-cluster/templates/role-binding.yaml
+++ b/charts/authentik-remote-cluster/templates/role-binding.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:

--- a/charts/authentik-remote-cluster/templates/role.yaml
+++ b/charts/authentik-remote-cluster/templates/role.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:

--- a/charts/authentik-remote-cluster/templates/service-account-secret.yaml
+++ b/charts/authentik-remote-cluster/templates/service-account-secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.serviceAccountSecret.enabled -}}
 ---
 apiVersion: v1
 kind: Secret
@@ -12,3 +13,4 @@ metadata:
     {{- with .Values.annotations }}
     {{- toYaml . | nindent 4 }}
     {{- end }}
+{{- end }}

--- a/charts/authentik-remote-cluster/templates/service-account-secret.yaml
+++ b/charts/authentik-remote-cluster/templates/service-account-secret.yaml
@@ -1,0 +1,14 @@
+---
+apiVersion: v1
+kind: Secret
+type: kubernetes.io/service-account-token
+metadata:
+  name: {{ include "authentik-remote-cluster.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "authentik-remote-cluster.labels" . | nindent 4 }}
+  annotations:
+    kubernetes.io/service-account.name: {{ include "authentik-remote-cluster.fullname" . }}
+    {{- with .Values.annotations }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}

--- a/charts/authentik-remote-cluster/templates/service-account.yaml
+++ b/charts/authentik-remote-cluster/templates/service-account.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:

--- a/charts/authentik-remote-cluster/values.yaml
+++ b/charts/authentik-remote-cluster/values.yaml
@@ -2,3 +2,6 @@ nameOverride: ""
 fullnameOverride: ""
 
 annotations: {}
+
+serviceAccountSecret:
+  enabled: true

--- a/charts/authentik/README.md
+++ b/charts/authentik/README.md
@@ -154,7 +154,7 @@ redis:
 | service.type | string | `"ClusterIP"` |  |
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `true` | Service account is needed for managed outposts |
-| serviceAccount.serviceAccountSecret | object | `{"enabled":false}` | As we use the authentik-remote-cluster chart as subchart, and that chart creates a service account secret by default which we don't need here, disable its creation |
+| serviceAccount.serviceAccountSecret.enabled | bool | `false` | As we use the authentik-remote-cluster chart as subchart, and that chart creates a service account secret by default which we don't need here, disable its creation |
 | tolerations | list | `[]` |  |
 | volumeMounts | list | `[]` |  |
 | volumes | list | `[]` |  |

--- a/charts/authentik/README.md
+++ b/charts/authentik/README.md
@@ -154,6 +154,7 @@ redis:
 | service.type | string | `"ClusterIP"` |  |
 | serviceAccount.annotations | object | `{}` |  |
 | serviceAccount.create | bool | `true` | Service account is needed for managed outposts |
+| serviceAccount.serviceAccountSecret | object | `{"enabled":false}` | As we use the authentik-remote-cluster chart as subchart, and that chart creates a service account secret by default which we don't need here, disable its creation |
 | tolerations | list | `[]` |  |
 | volumeMounts | list | `[]` |  |
 | volumes | list | `[]` |  |

--- a/charts/authentik/values.yaml
+++ b/charts/authentik/values.yaml
@@ -169,9 +169,9 @@ serviceAccount:
   # -- Service account is needed for managed outposts
   create: true
   annotations: {}
-  # -- As we use the authentik-remote-cluster chart as subchart, and that chart
-  # creates a service account secret by default which we don't need here, disable its creation
   serviceAccountSecret:
+    # -- As we use the authentik-remote-cluster chart as subchart, and that chart
+    # creates a service account secret by default which we don't need here, disable its creation
     enabled: false
 
 prometheus:

--- a/charts/authentik/values.yaml
+++ b/charts/authentik/values.yaml
@@ -169,6 +169,10 @@ serviceAccount:
   # -- Service account is needed for managed outposts
   create: true
   annotations: {}
+  # -- As we use the authentik-remote-cluster chart as subchart, and that chart
+  # creates a service account secret by default which we don't need here, disable its creation
+  serviceAccountSecret:
+    enabled: false
 
 prometheus:
   serviceMonitor:


### PR DESCRIPTION
In Kubernetes 1.24, Service Accounts no longer create a default Secret.

Since the user relies on fetching said secret for generating the kubeconfig, this PR fixes the missing Secret by creating it and referencing the Service Account as part of the Helm Chart install.