### PR TITLE
feat(postgres): bump to 12.x image

### DIFF
--- a/charts/authentik/values.yaml
+++ b/charts/authentik/values.yaml
@@ -241,7 +241,7 @@ postgresql:
   #   accessModes:
   #     - ReadWriteOnce
   image:
-    tag: 11.19.0-debian-11-r4
+    tag: 12.16.0-debian-11-r2
 redis:
   # -- enable the bundled bitnami redis chart
   enabled: false


### PR DESCRIPTION
Newer builds of Authentik are requiring Postgres versions >11.x

```
{"event": "Internal Server Error: /-/health/live/", "exc_info": ["<class 'django.db.utils.NotSupportedError'>", "NotSupportedError('PostgreSQL 12 or later is required (found 11.19).')", "<traceback object at 0x7fe1be1b4e40>"], "level": "error", "logger": "django.request", "timestamp": 1692113199.0965452}
```