### PR TITLE
feat(charts/authentik): Add custom dns config to worker pods

### DIFF
--- a/charts/authentik/templates/worker-deployment.yaml
+++ b/charts/authentik/templates/worker-deployment.yaml
@@ -154,6 +154,11 @@ spec:
       {{- with $.Values.volumes }}
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with $.Values.worker.dns }}
+      dnsPolicy: {{ default "Default" .policy }}
+      dnsConfig:
+        {{- toYaml .config | nindent 8  }}
+      {{- end }}
       {{- with $.Values.blueprints }}
         {{- range $name := . }}
         - name: blueprints-{{ $name }}

--- a/charts/authentik/values.yaml
+++ b/charts/authentik/values.yaml
@@ -28,6 +28,17 @@ worker:
     # rollingUpdate:
     #  maxSurge: 25%
     #  maxUnavailable: 25%
+  # -- worker dns configuration
+  dns: {}
+    # policy: None
+    # config:
+    #   nameservers:
+    #     - 1.1.1.1
+    #   searches:
+    #     - ns1.svc.cluster-domain.example
+    #   options:
+    #     - name: ndots
+    #       value: 2
 
 image:
   repository: ghcr.io/goauthentik/server


### PR DESCRIPTION
This PR adds a `worker.dns` to `values.yaml`, which would allow you to customize `DNSPolicy` and `DNSConfig` for the worker pod(s).