### PR TITLE
authentik: fix extraContainers indentation

### DIFF
--- a/charts/authentik/templates/server/deployment.yaml
+++ b/charts/authentik/templates/server/deployment.yaml
@@ -182,7 +182,7 @@ spec:
           {{- end }}
         {{- end }}
         {{- with .Values.server.extraContainers }}
-          {{- tpl (toYaml . ) $ | nindent 6 }}
+          {{- tpl (toYaml . ) $ | nindent 8 }}
         {{- end }}
       {{- with include "authentik.affinity" (dict "context" . "component" .Values.server) }}
       affinity:

--- a/charts/authentik/templates/worker/deployment.yaml
+++ b/charts/authentik/templates/worker/deployment.yaml
@@ -165,7 +165,7 @@ spec:
           {{- end }}
         {{- end }}
         {{- with .Values.worker.extraContainers }}
-          {{- tpl (toYaml . ) $ | nindent 6 }}
+          {{- tpl (toYaml . ) $ | nindent 8 }}
         {{- end }}
       {{- with include "authentik.affinity" (dict "context" . "component" .Values.worker) }}
       affinity:


### PR DESCRIPTION
solve bug #247  
created by @rissson  on #230

contains #248 which shows the bug