### PR TITLE
authentik: add option to set serviceaccount

### DIFF
--- a/charts/authentik/Chart.yaml
+++ b/charts/authentik/Chart.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: v2
-version: 2024.2.3
+version: 2024.2.2
 appVersion: 2024.2.2
 name: authentik
 description: authentik is an open-source Identity Provider focused on flexibility and versatility

--- a/charts/authentik/Chart.yaml
+++ b/charts/authentik/Chart.yaml
@@ -1,6 +1,6 @@
 ---
 apiVersion: v2
-version: 2024.2.2
+version: 2024.2.3
 appVersion: 2024.2.2
 name: authentik
 description: authentik is an open-source Identity Provider focused on flexibility and versatility

--- a/charts/authentik/README.md
+++ b/charts/authentik/README.md
@@ -281,6 +281,7 @@ The secret `authentik-postgres-credentials` must have `username` and `password` 
 | server.service.sessionAffinity | string | `""` | Used to maintain session affinity. Supports `ClientIP` and `None` |
 | server.service.sessionAffinityConfig | object | `{}` | Session affinity configuration |
 | server.service.type | string | `"ClusterIP"` | authentik server service type |
+| server.serviceAccount | string | `nil` | serviceAccount for usage of server pods |
 | server.startupProbe.failureThreshold | int | `60` | Minimum consecutive failures for the [probe] to be considered failed after having succeeded |
 | server.startupProbe.httpGet.path | string | `"/-/health/live/"` |  |
 | server.startupProbe.httpGet.port | string | `"http"` |  |
@@ -334,6 +335,7 @@ The secret `authentik-postgres-credentials` must have `username` and `password` 
 | worker.replicas | int | `1` | The number of worker pods to run |
 | worker.resources | object | `{}` | Resource limits and requests for the authentik worker |
 | worker.securityContext | object | `{}` (See [values.yaml]) | authentik worker pod-level security context |
+| worker.serviceAccount | string | `nil` | serviceAccount for usage of worker pods |
 | worker.terminationGracePeriodSeconds | int | `30` | terminationGracePeriodSeconds for container lifecycle hook |
 | worker.tolerations | list | `[]` (defaults to global.tolerations) | [Tolerations] for use with node taints |
 | worker.topologySpreadConstraints | list | `[]` (defaults to global.topologySpreadConstraints) | Assign custom [TopologySpreadConstraints] rules to the authentik worker # Ref: https://kubernetes.io/docs/concepts/workloads/pods/pod-topology-spread-constraints/ # If labelSelector is left out, it will default to the labelSelector configuration of the deployment |

--- a/charts/authentik/templates/server/deployment.yaml
+++ b/charts/authentik/templates/server/deployment.yaml
@@ -42,6 +42,9 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.server.serviceAccount }}
+      serviceAccountName: {{ . }}
+      {{- end }}
       {{- with .Values.global.hostAliases }}
       hostAliases:
         {{- toYaml . | nindent 8 }}

--- a/charts/authentik/templates/server/deployment.yaml
+++ b/charts/authentik/templates/server/deployment.yaml
@@ -42,7 +42,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.server.serviceAccount }}
+      {{- with .Values.server.serviceAccountName }}
       serviceAccountName: {{ . }}
       {{- end }}
       {{- with .Values.global.hostAliases }}

--- a/charts/authentik/templates/worker/deployment.yaml
+++ b/charts/authentik/templates/worker/deployment.yaml
@@ -42,8 +42,12 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.worker.serviceAccount }}
+      serviceAccountName: {{ . }}
+      {{- else }}
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ include "authentik-remote-cluster.fullname" .Subcharts.serviceAccount }}
+      {{- end }}
       {{- end }}
       {{- with .Values.global.hostAliases }}
       hostAliases:

--- a/charts/authentik/templates/worker/deployment.yaml
+++ b/charts/authentik/templates/worker/deployment.yaml
@@ -42,7 +42,7 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.worker.serviceAccount }}
+      {{- with .Values.worker.serviceAccountName }}
       serviceAccountName: {{ . }}
       {{- else }}
       {{- if .Values.serviceAccount.create }}

--- a/charts/authentik/values.yaml
+++ b/charts/authentik/values.yaml
@@ -370,6 +370,9 @@ server:
   # -- Alternative DNS policy for authentik server pods
   dnsPolicy: ""
 
+  # -- serviceAccount for usage of server pods
+  serviceAccount:
+
   # -- authentik server pod-level security context
   # @default -- `{}` (See [values.yaml])
   securityContext: {}
@@ -745,6 +748,9 @@ worker:
   dnsConfig: {}
   # -- Alternative DNS policy for authentik worker pods
   dnsPolicy: ""
+
+  # -- serviceAccount for usage of worker pods
+  serviceAccount:
 
   # -- authentik worker pod-level security context
   # @default -- `{}` (See [values.yaml])

--- a/charts/authentik/values.yaml
+++ b/charts/authentik/values.yaml
@@ -370,8 +370,8 @@ server:
   # -- Alternative DNS policy for authentik server pods
   dnsPolicy: ""
 
-  # -- serviceAccount for usage of server pods
-  serviceAccount:
+  # -- serviceAccount to use for authentik server pods
+  serviceAccountName: ~
 
   # -- authentik server pod-level security context
   # @default -- `{}` (See [values.yaml])
@@ -749,8 +749,8 @@ worker:
   # -- Alternative DNS policy for authentik worker pods
   dnsPolicy: ""
 
-  # -- serviceAccount for usage of worker pods
-  serviceAccount:
+  # -- serviceAccount to use for authentik worker pods. If set, overrides the value used when serviceAccount.create is true
+  serviceAccountName: ~
 
   # -- authentik worker pod-level security context
   # @default -- `{}` (See [values.yaml])


### PR DESCRIPTION
I like to follow security guide lines, which say nobody should use the "default" serviceAccount of an namespace ... 

so i like to create my own serviceAccount and assign it with this helm-chart.

PS: maybe it is also needed for #146 