### PR TITLE
authentik: worker deployment: fix volume type for secret blueprints

### DIFF
--- a/charts/authentik/templates/worker/deployment.yaml
+++ b/charts/authentik/templates/worker/deployment.yaml
@@ -209,7 +209,7 @@ spec:
       {{- end }}
       {{- range $name := .Values.blueprints.secrets }}
         - name: blueprints-secret-{{ $name }}
-          configMap:
+          secret:
             name: {{ $name }}
       {{- end }}
       {{- end }}


### PR DESCRIPTION
This fixes https://github.com/goauthentik/helm/issues/256