### PR TITLE
Fix secret key name

### DIFF
--- a/charts/authentik/templates/worker/deployment.yaml
+++ b/charts/authentik/templates/worker/deployment.yaml
@@ -209,7 +209,7 @@ spec:
       {{- end }}
       {{- range $name := .Values.blueprints.secrets }}
         - name: blueprints-secret-{{ $name }}
-          configMap:
+          secret:
             name: {{ $name }}
       {{- end }}
       {{- end }}

--- a/charts/authentik/templates/worker/deployment.yaml
+++ b/charts/authentik/templates/worker/deployment.yaml
@@ -210,7 +210,7 @@ spec:
       {{- range $name := .Values.blueprints.secrets }}
         - name: blueprints-secret-{{ $name }}
           secret:
-            name: {{ $name }}
+            secretName: {{ $name }}
       {{- end }}
       {{- end }}
       enableServiceLinks: true


### PR DESCRIPTION
The fix applied in https://github.com/goauthentik/helm/pull/257 did not take into consideration that when using a secret the key is `secretName` and not `name`

This PR fixes this issue