### PR TITLE
fix(charts/authentik): hpa yaml memory was invalid

### DIFF
--- a/charts/authentik/templates/server/hpa.yaml
+++ b/charts/authentik/templates/server/hpa.yaml
@@ -25,8 +25,9 @@ spec:
     - type: Resource
       resource:
         name: memory
-        target: Utilization
-        averageUtilization: {{ . }}
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
     {{- end }}
     {{- with .Values.server.autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource

--- a/charts/authentik/templates/worker/hpa.yaml
+++ b/charts/authentik/templates/worker/hpa.yaml
@@ -25,8 +25,9 @@ spec:
     - type: Resource
       resource:
         name: memory
-        target: Utilization
-        averageUtilization: {{ . }}
+        target:
+          type: Utilization
+          averageUtilization: {{ . }}
     {{- end }}
     {{- with .Values.worker.autoscaling.targetCPUUtilizationPercentage }}
     - type: Resource


### PR DESCRIPTION
Fix of wrong yaml structure in HorizontalPodAutoscaler object in worker and server template.