### PR TITLE
Add .Values.global.secretAnnotations

### DIFF
--- a/charts/authentik/templates/secret.yaml
+++ b/charts/authentik/templates/secret.yaml
@@ -5,9 +5,9 @@ metadata:
   namespace: {{ .Release.Namespace | quote }}
   labels:
     {{- include "authentik.labels" (dict "context" .) | nindent 4 }}
-  {{- if .Values.annotations }}
+  {{- if .Values.global.secretAnnotations }}
   annotations:
-    {{- toYaml .Values.annotations | nindent 4 }}
+    {{- toYaml .Values.global.secretAnnotations | nindent 4 }}
   {{- end }}
 data:
   {{- include "authentik.env" (dict "root" . "values" .Values.authentik) | indent 2 }}

--- a/charts/authentik/values.yaml
+++ b/charts/authentik/values.yaml
@@ -40,6 +40,9 @@ global:
   # -- Annotations for all deployed pods
   podAnnotations: {}
 
+  # -- Annotations for all deployed secrets
+  secretAnnotations: {}
+
   # -- Labels for all deployed pods
   podLabels: {}
 


### PR DESCRIPTION
Recently ran into a situation where setting annotations on secrets would be helpful to prevent mutation by webhooks.

Added what seems to have been missed when deprecating `.Values.annotations`