### PR TITLE
make smtp use_ssl/use_tls setting docs clearer

### DIFF
--- a/charts/authentik/README.md
+++ b/charts/authentik/README.md
@@ -105,8 +105,8 @@ The secret `authentik-postgres-credentials` must have `username` and `password` 
 | authentik.email.password | string | `""` | SMTP credentials, when left empty, no authentication will be done |
 | authentik.email.port | int | `587` | SMTP server port |
 | authentik.email.timeout | int | `30` | Connection timeout |
-| authentik.email.use_ssl | bool | `false` | Enable either use_tls or use_ssl, they can't be enabled at the same time. |
-| authentik.email.use_tls | bool | `false` | Enable either use_tls or use_ssl, they can't be enabled at the same time. |
+| authentik.email.use_ssl | bool | `false` | Use SSL. Enable either use_tls or use_ssl, they can't be enabled at the same time. |
+| authentik.email.use_tls | bool | `false` | Use StartTLS. Enable either use_tls or use_ssl, they can't be enabled at the same time. |
 | authentik.email.username | string | `""` | SMTP credentials, when left empty, no authentication will be done |
 | authentik.error_reporting.enabled | bool | `false` | This sends anonymous usage-data, stack traces on errors and performance data to sentry.beryju.org, and is fully opt-in |
 | authentik.error_reporting.environment | string | `"k8s"` | This is a string that is sent to sentry with your error reports |

--- a/charts/authentik/values.yaml
+++ b/charts/authentik/values.yaml
@@ -166,9 +166,9 @@ authentik:
     username: ""
     # -- SMTP credentials, when left empty, no authentication will be done
     password: ""
-    # -- Enable either use_tls or use_ssl, they can't be enabled at the same time.
+    # -- Use StartTLS. Enable either use_tls or use_ssl, they can't be enabled at the same time.
     use_tls: false
-    # -- Enable either use_tls or use_ssl, they can't be enabled at the same time.
+    # -- Use SSL. Enable either use_tls or use_ssl, they can't be enabled at the same time.
     use_ssl: false
     # -- Connection timeout
     timeout: 30


### PR DESCRIPTION
It wasn't clear (to me at least) what the `email.use_ssl` and `email.use_tls` (mutually exclusive) settings did. Judging from [the docs here](https://github.com/goauthentik/authentik/blob/64f1b8207d63647a26b9912e96bffda43256623c/website/docs/install-config/install/docker-compose.mdx#L80), it seems like `use_tls` enables StartTLS, while `use_ssl` enables the more modern ssl/tls encryption. I've updated the comments to make that more clear.