### PR TITLE
Fix removed whitespace for additionalObjects

### DIFF
--- a/charts/authentik/templates/additional-objects.yaml
+++ b/charts/authentik/templates/additional-objects.yaml
@@ -1,4 +1,4 @@
 {{- range .Values.additionalObjects }}
 ---
-{{- tpl (toYaml . ) $ }}
+{{ tpl (toYaml . ) $ }}
 {{- end }}


### PR DESCRIPTION
If whitespace is cleared preceeding the `tpl` line, then the first line ends up looking something like `---apiVersion: ...`, removing an important newline. `helm template` is able to handle this, but `helm lint` fails as documented in https://github.com/helm/helm/issues/10149 due to the generated yaml being invalid.