### PR TITLE
charts/authentik: add automountServiceAccountToken value

### DIFF
--- a/charts/authentik/README.md
+++ b/charts/authentik/README.md
@@ -345,6 +345,7 @@ The secret `authentik-postgres-credentials` must have `username` and `password` 
 | serviceAccount.fullnameOverride | string | `"authentik"` |  |
 | serviceAccount.serviceAccountSecret.enabled | bool | `false` |  |
 | worker.affinity | object | `{}` (defaults to the global.affinity preset) | Assign custom [affinity] rules to the deployment |
+| worker.automountServiceAccountToken | bool | `nil` | automount behavior for service account token in worker pods. Only applies if worker.serviceAccountName is set. |
 | worker.autoscaling.behavior | object | `{}` | Configures the scaling behavior of the target in both Up and Down directions. |
 | worker.autoscaling.enabled | bool | `false` | Enable Horizontal Pod Autoscaler ([HPA]) for the authentik worker |
 | worker.autoscaling.maxReplicas | int | `5` | Maximum number of replicas for the authentik worker [HPA] |

--- a/charts/authentik/templates/worker/deployment.yaml
+++ b/charts/authentik/templates/worker/deployment.yaml
@@ -45,6 +45,9 @@ spec:
       {{- end }}
       {{- with .Values.worker.serviceAccountName }}
       serviceAccountName: {{ . }}
+      {{- with $.Values.worker.automountServiceAccountToken }}
+      automountServiceAccountToken:  {{ . }}
+      {{- end }}
       {{- else }}
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ include "authentik-remote-cluster.fullname" .Subcharts.serviceAccount }}

--- a/charts/authentik/values.yaml
+++ b/charts/authentik/values.yaml
@@ -819,6 +819,8 @@ worker:
 
   # -- serviceAccount to use for authentik worker pods. If set, overrides the value used when serviceAccount.create is true
   serviceAccountName: ~
+  # -- (bool) automount behavior for service account token in worker pods. Only applies if worker.serviceAccountName is set.
+  automountServiceAccountToken: ~
 
   # -- authentik worker pod-level security context
   # @default -- `{}` (See [values.yaml])


### PR DESCRIPTION
This adds an implementation proposal for issue #406 

Am I correct in manually adding the new value to the README or is this automatically done using a pipeline?

Suggestions and guidance, especially on helm template style are welcome :)

Closes #406