### PR TITLE
charts/authentik: worker: add support for multiple queue workers

### DIFF
--- a/charts/authentik/templates/worker/deployment.yaml
+++ b/charts/authentik/templates/worker/deployment.yaml
@@ -1,4 +1,13 @@
 {{- if .Values.worker.enabled }}
+{{/*
+Minimize changing every "." for $root by overlapping the workerconfig on top of
+the current root + a with block.
+*/}}
+{{- $root := . -}}
+{{- $defaultWorker := (dict "default" (dict)) -}}
+{{- range $queueName, $workerConfig := (default $defaultWorker $root.Values.worker.queues) -}}
+{{- $newRoot := mustMergeOverwrite (dict) $root (dict "Values" (dict "worker" $workerConfig)) -}}
+{{- with $newRoot -}}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -75,8 +84,10 @@ spec:
         - name: {{ .Values.worker.name }}
           image: {{ default .Values.global.image.repository .Values.worker.image.repository }}:{{ default (include "authentik.defaultTag" .) .Values.worker.image.tag }}{{- if (default .Values.global.image.digest .Values.worker.image.digest) -}}@{{ default .Values.global.image.digest .Values.worker.image.digest }}{{- end }}
           imagePullPolicy: {{ default .Values.global.image.pullPolicy .Values.worker.image.pullPolicy }}
+          {{- with default (list "worker") .Values.worker.args }}
           args:
-            - worker
+            {{- . | toYaml | nindent 12 }}
+          {{- end }}
           env:
             {{- with (concat .Values.global.env .Values.worker.env) }}
               {{- toYaml . | nindent 12 }}
@@ -255,4 +266,7 @@ spec:
       {{- if .Values.worker.dnsPolicy }}
       dnsPolicy: {{ .Values.worker.dnsPolicy }}
       {{- end }}
+...
+{{- end -}}
+{{ end -}}
 {{- end }}

--- a/charts/authentik/values.yaml
+++ b/charts/authentik/values.yaml
@@ -662,8 +662,12 @@ worker:
   # -- whether to enable worker resources
   enabled: true
 
-  # -- authentik worker name
-  name: worker
+  ## authentik worker queue distribution
+  #  key => worker config definition
+  #
+  queues:
+    default:
+      name: worker
 
   # -- The number of worker pods to run
   replicas: 1


### PR DESCRIPTION
Introducing `.Values.worker.queues` to provide a way to replicate the worker deployment with customizations.

The default value:

```yaml
#...
worker:
  ## authentik worker queue distribution
  #  key => worker config definition
  #
  queues:
    default:
      name: worker
```

Will emit the same deployment, but by providing:

```yaml
#...
worker:
  ## authentik worker queue distribution
  #  key => worker config definition
  #
  queues:
    default:
      name: worker
    high-priority:
      replicas: 2
      name: worker-high-priority
      args:
        - worker
        - --queues
        - high-priority
```

The values on the `.Values.worker.queues.*` are merged with `.Values.worker` so defaults can be set for all deployments, and every queue deployment can scale up/down or have special affinities or `args` (like in the example)