### PR TITLE
charts/authentik: remove hardcoded AUTHENTIK_LISTEN variables

### DIFF
--- a/charts/authentik/templates/server/deployment.yaml
+++ b/charts/authentik/templates/server/deployment.yaml
@@ -74,12 +74,6 @@ spec:
             {{- with (concat .Values.global.env .Values.server.env) }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
-            - name: AUTHENTIK_LISTEN__HTTP
-              value: {{ printf "0.0.0.0:%v" .Values.server.containerPorts.http | quote }}
-            - name: AUTHENTIK_LISTEN__HTTPS
-              value: {{ printf "0.0.0.0:%v" .Values.server.containerPorts.https | quote }}
-            - name: AUTHENTIK_LISTEN__METRICS
-              value: {{ printf "0.0.0.0:%v" .Values.server.containerPorts.metrics | quote }}
           envFrom:
             - secretRef:
                 name: {{ template "authentik.secret.name" . }}

--- a/charts/authentik/templates/worker/deployment.yaml
+++ b/charts/authentik/templates/worker/deployment.yaml
@@ -81,10 +81,6 @@ spec:
             {{- with (concat .Values.global.env .Values.worker.env) }}
               {{- toYaml . | nindent 12 }}
             {{- end }}
-            - name: AUTHENTIK_LISTEN__HTTP
-              value: {{ printf "0.0.0.0:%v" .Values.worker.containerPorts.http | quote }}
-            - name: AUTHENTIK_LISTEN__METRICS
-              value: {{ printf "0.0.0.0:%v" .Values.worker.containerPorts.metrics | quote }}
           envFrom:
             - secretRef:
                 name: {{ template "authentik.secret.name" . }}


### PR DESCRIPTION
This change brings back some flexibility for users