### PR TITLE
charts/authentik: improve explanation of the authentik.existingSecret

### DIFF
--- a/charts/authentik/README.md
+++ b/charts/authentik/README.md
@@ -120,7 +120,7 @@ The secret `authentik-postgres-credentials` must have `username` and `password` 
 | authentik.error_reporting.send_pii | bool | `false` | Send PII (Personally identifiable information) data to sentry |
 | authentik.events.context_processors.asn | string | `"/geoip/GeoLite2-ASN.mmdb"` | Path for the GeoIP ASN database. If the file doesn't exist, GeoIP features are disabled. |
 | authentik.events.context_processors.geoip | string | `"/geoip/GeoLite2-City.mmdb"` | Path for the GeoIP City database. If the file doesn't exist, GeoIP features are disabled. |
-| authentik.existingSecret.secretName | string | `""` | name of an existing secret to use for authentik configuration. The map key must be AUTHENTIK_SECRET_KEY |
+| authentik.existingSecret.secretName | string | `""` | name of an existing secret to use for authentik configuration. The keys in the secret must be environment variables, see the docs for the full list of configuration options https://docs.goauthentik.io/install-config/configuration/ |
 | authentik.log_level | string | `"info"` | Log level for server and worker |
 | authentik.outposts.container_image_base | string | `"ghcr.io/goauthentik/%(type)s:%(version)s"` | Template used for managed outposts. The following placeholders can be used %(type)s - the type of the outpost %(version)s - version of your authentik install %(build_hash)s - only for beta versions, the build hash of the image |
 | authentik.postgresql.host | string | `{{ .Release.Name }}-postgresql` | set the postgresql hostname to talk to if unset and .Values.postgresql.enabled == true, will generate the default |

--- a/charts/authentik/README.md
+++ b/charts/authentik/README.md
@@ -120,7 +120,7 @@ The secret `authentik-postgres-credentials` must have `username` and `password` 
 | authentik.error_reporting.send_pii | bool | `false` | Send PII (Personally identifiable information) data to sentry |
 | authentik.events.context_processors.asn | string | `"/geoip/GeoLite2-ASN.mmdb"` | Path for the GeoIP ASN database. If the file doesn't exist, GeoIP features are disabled. |
 | authentik.events.context_processors.geoip | string | `"/geoip/GeoLite2-City.mmdb"` | Path for the GeoIP City database. If the file doesn't exist, GeoIP features are disabled. |
-| authentik.existingSecret.secretName | string | `""` | name of an existing secret to use for authentik configuration. The keys in the secret must be environment variables, see the docs for the full list of configuration options https://docs.goauthentik.io/install-config/configuration/ |
+| authentik.existingSecret.secretName | string | `""` | name of an existing secret to use for authentik configuration. This secret must contain keys matching configuration option names, see the docs for the full list of configuration options https://docs.goauthentik.io/install-config/configuration/ |
 | authentik.log_level | string | `"info"` | Log level for server and worker |
 | authentik.outposts.container_image_base | string | `"ghcr.io/goauthentik/%(type)s:%(version)s"` | Template used for managed outposts. The following placeholders can be used %(type)s - the type of the outpost %(version)s - version of your authentik install %(build_hash)s - only for beta versions, the build hash of the image |
 | authentik.postgresql.host | string | `{{ .Release.Name }}-postgresql` | set the postgresql hostname to talk to if unset and .Values.postgresql.enabled == true, will generate the default |

--- a/charts/authentik/README.md
+++ b/charts/authentik/README.md
@@ -120,7 +120,7 @@ The secret `authentik-postgres-credentials` must have `username` and `password` 
 | authentik.error_reporting.send_pii | bool | `false` | Send PII (Personally identifiable information) data to sentry |
 | authentik.events.context_processors.asn | string | `"/geoip/GeoLite2-ASN.mmdb"` | Path for the GeoIP ASN database. If the file doesn't exist, GeoIP features are disabled. |
 | authentik.events.context_processors.geoip | string | `"/geoip/GeoLite2-City.mmdb"` | Path for the GeoIP City database. If the file doesn't exist, GeoIP features are disabled. |
-| authentik.existingSecret.secretName | string | `""` | name of an existing secret to use for authentik configuration |
+| authentik.existingSecret.secretName | string | `""` | name of an existing secret to use for authentik configuration. The map key must be AUTHENTIK_SECRET_KEY |
 | authentik.log_level | string | `"info"` | Log level for server and worker |
 | authentik.outposts.container_image_base | string | `"ghcr.io/goauthentik/%(type)s:%(version)s"` | Template used for managed outposts. The following placeholders can be used %(type)s - the type of the outpost %(version)s - version of your authentik install %(build_hash)s - only for beta versions, the build hash of the image |
 | authentik.postgresql.host | string | `{{ .Release.Name }}-postgresql` | set the postgresql hostname to talk to if unset and .Values.postgresql.enabled == true, will generate the default |

--- a/charts/authentik/values.yaml
+++ b/charts/authentik/values.yaml
@@ -159,7 +159,7 @@ authentik:
   ## use existing secret for authentik configuration instead of creating one
   ## WARNING: when set, authentik.* secret values are ignored
   existingSecret:
-    # -- name of an existing secret to use for authentik configuration. The map key must be AUTHENTIK_SECRET_KEY
+    # -- name of an existing secret to use for authentik configuration. The keys in the secret must be environment variables, see the docs for the full list of configuration options https://docs.goauthentik.io/install-config/configuration/
     secretName: ""
   events:
     context_processors:

--- a/charts/authentik/values.yaml
+++ b/charts/authentik/values.yaml
@@ -159,7 +159,7 @@ authentik:
   ## use existing secret for authentik configuration instead of creating one
   ## WARNING: when set, authentik.* secret values are ignored
   existingSecret:
-    # -- name of an existing secret to use for authentik configuration. The keys in the secret must be environment variables, see the docs for the full list of configuration options https://docs.goauthentik.io/install-config/configuration/
+    # -- name of an existing secret to use for authentik configuration. This secret must contain keys matching configuration option names, see the docs for the full list of configuration options https://docs.goauthentik.io/install-config/configuration/
     secretName: ""
   events:
     context_processors:

--- a/charts/authentik/values.yaml
+++ b/charts/authentik/values.yaml
@@ -159,7 +159,7 @@ authentik:
   ## use existing secret for authentik configuration instead of creating one
   ## WARNING: when set, authentik.* secret values are ignored
   existingSecret:
-    # -- name of an existing secret to use for authentik configuration
+    # -- name of an existing secret to use for authentik configuration. The map key must be AUTHENTIK_SECRET_KEY
     secretName: ""
   events:
     context_processors:


### PR DESCRIPTION
This adds a small note of the key in the kubernetes secret thats used by authentik.existingSecret
