### PR TITLE
charts/authentik: add server automountServiceAccountToken value

### DIFF
--- a/charts/authentik/README.md
+++ b/charts/authentik/README.md
@@ -219,6 +219,7 @@ The secret `authentik-postgres-credentials` must have `username` and `password` 
 | prometheus.rules.namespace | string | `""` | PrometheusRule namespace |
 | prometheus.rules.selector | object | `{}` | PrometheusRule selector |
 | server.affinity | object | `{}` (defaults to the global.affinity preset) | Assign custom [affinity] rules to the deployment |
+| server.automountServiceAccountToken | bool | `nil` | automount behavior for service account token in server pods. Only applies if server.serviceAccountName is set. |
 | server.autoscaling.behavior | object | `{}` | Configures the scaling behavior of the target in both Up and Down directions. |
 | server.autoscaling.enabled | bool | `false` | Enable Horizontal Pod Autoscaler ([HPA]) for the authentik server |
 | server.autoscaling.maxReplicas | int | `5` | Maximum number of replicas for the authentik server [HPA] |

--- a/charts/authentik/templates/server/deployment.yaml
+++ b/charts/authentik/templates/server/deployment.yaml
@@ -45,6 +45,9 @@ spec:
       {{- end }}
       {{- with .Values.server.serviceAccountName }}
       serviceAccountName: {{ . }}
+      {{- with $.Values.server.automountServiceAccountToken }}
+      automountServiceAccountToken:  {{ . }}
+      {{- end }}
       {{- end }}
       {{- with .Values.global.hostAliases }}
       hostAliases:

--- a/charts/authentik/values.yaml
+++ b/charts/authentik/values.yaml
@@ -392,6 +392,8 @@ server:
 
   # -- serviceAccount to use for authentik server pods
   serviceAccountName: ~
+  # -- (bool) automount behavior for service account token in server pods. Only applies if server.serviceAccountName is set.
+  automountServiceAccountToken: ~
 
   # -- authentik server pod-level security context
   # @default -- `{}` (See [values.yaml])


### PR DESCRIPTION
Adds an optional `server.automountServiceAccountToken` value, mirroring the existing `worker.automountServiceAccountToken` added in #407. It lets operators control service account token automounting on the authentik server pods. Like the worker setting, it only applies when `server.serviceAccountName` is set, and it uses the same template guard so server matches worker.

Validation (local):
- `helm lint`: 1 chart linted, 0 failed
- `helm template` on the server deployment:
  - default (serviceAccountName unset): no `automountServiceAccountToken` field rendered, so the render is byte-identical to current for existing users
  - serviceAccountName set, automount unset: no `automountServiceAccountToken` field
  - serviceAccountName set, `automountServiceAccountToken: true`: renders `automountServiceAccountToken: true`

Files: `values.yaml` (+2), `templates/server/deployment.yaml` (+3), `README.md` (+1, helm-docs row).

related: #407