### PR TITLE
charts/authentik: avoid mounting envFrom secret if secret configuration disabled

### DIFF
--- a/charts/authentik/templates/server/deployment.yaml
+++ b/charts/authentik/templates/server/deployment.yaml
@@ -78,8 +78,10 @@ spec:
               {{- toYaml . | nindent 12 }}
             {{- end }}
           envFrom:
+            {{- if or .Values.authentik.enabled .Values.authentik.existingSecret.secretName }}
             - secretRef:
                 name: {{ template "authentik.secret.name" . }}
+            {{- end }}
             {{- with (concat .Values.global.envFrom .Values.server.envFrom) }}
               {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/authentik/templates/worker/deployment.yaml
+++ b/charts/authentik/templates/worker/deployment.yaml
@@ -82,8 +82,10 @@ spec:
               {{- toYaml . | nindent 12 }}
             {{- end }}
           envFrom:
+            {{- if or .Values.authentik.enabled .Values.authentik.existingSecret.secretName }}
             - secretRef:
                 name: {{ template "authentik.secret.name" . }}
+            {{- end }}
             {{- with (concat .Values.global.envFrom .Values.worker.envFrom) }}
               {{- toYaml . | nindent 12 }}
             {{- end }}


### PR DESCRIPTION
If a user wants to configure authentik by only providing environment variables (eg: .Values.global.env), disabling the secret creation and not setting existing secret doesn't stop the envFrom from being templated in the deployments.

Sourcing configuration from env only could be useful to source config from different secrets (I'm using CNPG and I source the PG passwords from a specific secret).