### PR TITLE
charts/authentik: render automountServiceAccountToken when set to false

### DIFF
--- a/charts/authentik/templates/server/deployment.yaml
+++ b/charts/authentik/templates/server/deployment.yaml
@@ -45,8 +45,8 @@ spec:
       {{- end }}
       {{- with .Values.server.serviceAccountName }}
       serviceAccountName: {{ . }}
-      {{- with $.Values.server.automountServiceAccountToken }}
-      automountServiceAccountToken:  {{ . }}
+      {{- if kindIs "bool" $.Values.server.automountServiceAccountToken }}
+      automountServiceAccountToken: {{ $.Values.server.automountServiceAccountToken }}
       {{- end }}
       {{- end }}
       {{- with .Values.global.hostAliases }}

--- a/charts/authentik/templates/worker/deployment.yaml
+++ b/charts/authentik/templates/worker/deployment.yaml
@@ -43,15 +43,13 @@ spec:
       imagePullSecrets:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with .Values.worker.serviceAccountName }}
-      serviceAccountName: {{ . }}
-      {{- if kindIs "bool" $.Values.worker.automountServiceAccountToken }}
-      automountServiceAccountToken: {{ $.Values.worker.automountServiceAccountToken }}
+      {{- if .Values.worker.serviceAccountName }}
+      serviceAccountName: {{ .Values.worker.serviceAccountName | quote }}
+      {{- else if .Values.serviceAccount.create }}
+      serviceAccountName: {{ include "authentik-remote-cluster.fullname" .Subcharts.serviceAccount | quote }}
       {{- end }}
-      {{- else }}
-      {{- if .Values.serviceAccount.create }}
-      serviceAccountName: {{ include "authentik-remote-cluster.fullname" .Subcharts.serviceAccount }}
-      {{- end }}
+      {{- if kindIs "bool" .Values.worker.automountServiceAccountToken }}
+      automountServiceAccountToken: {{ .Values.worker.automountServiceAccountToken }}
       {{- end }}
       {{- with .Values.global.hostAliases }}
       hostAliases:

--- a/charts/authentik/templates/worker/deployment.yaml
+++ b/charts/authentik/templates/worker/deployment.yaml
@@ -45,8 +45,8 @@ spec:
       {{- end }}
       {{- with .Values.worker.serviceAccountName }}
       serviceAccountName: {{ . }}
-      {{- with $.Values.worker.automountServiceAccountToken }}
-      automountServiceAccountToken:  {{ . }}
+      {{- if kindIs "bool" $.Values.worker.automountServiceAccountToken }}
+      automountServiceAccountToken: {{ $.Values.worker.automountServiceAccountToken }}
       {{- end }}
       {{- else }}
       {{- if .Values.serviceAccount.create }}


### PR DESCRIPTION
### Summary

Two fixes related to `automountServiceAccountToken`. 

First one is that Go templates treat `false` as empty in `with` blocks, so `automountServiceAccountToken: false` is never rendered (server and worker).

Second is that `automountServiceAccountToken` is ignored (on worker) when using `serviceAccount.create: true`.


