### PR TITLE
charts/authentik: gate the migrations rules behind a value

### DIFF
--- a/charts/authentik/README.md
+++ b/charts/authentik/README.md
@@ -216,6 +216,7 @@ The secret `authentik-postgres-credentials` must have `username` and `password` 
 | prometheus.rules.annotations | object | `{}` | PrometheusRule annotations |
 | prometheus.rules.enabled | bool | `false` |  |
 | prometheus.rules.labels | object | `{}` | PrometheusRule labels |
+| prometheus.rules.migrations.enabled | bool | `false` | Emit the migration recording rules and the `PendingMigrations` alert. Off by default: the default deployment applies migrations during startup, before metrics are served, so `django_migrations_unapplied_total` is never exported and the alert can never fire. Enable it if you run migrations as a separate step, where authentik can serve against a database whose migrations have not been applied yet. |
 | prometheus.rules.namespace | string | `""` | PrometheusRule namespace |
 | prometheus.rules.selector | object | `{}` | PrometheusRule selector |
 | server.affinity | object | `{}` (defaults to the global.affinity preset) | Assign custom [affinity] rules to the deployment |

--- a/charts/authentik/templates/prometheusrule.yaml
+++ b/charts/authentik/templates/prometheusrule.yaml
@@ -131,6 +131,7 @@ spec:
         - record: job:django_db_errors_total:sum_rate30s
           expr: sum(rate(django_db_errors_total[30s])) by (alias, vendor, type)
 
+    {{- if .Values.prometheus.rules.migrations.enabled }}
     - name: authentik Aggregate migrations
       {{- if .Values.prometheus.rules.additionalRuleGroupAnnotations }}
       annotations:
@@ -141,6 +142,7 @@ spec:
           expr: max(django_migrations_applied_total) by (job, connection)
         - record: job:django_migrations_unapplied_total:max
           expr: max(django_migrations_unapplied_total) by (job, connection)
+    {{- end }}
 
     - name: authentik Alerts
       {{- if .Values.prometheus.rules.additionalRuleGroupAnnotations }}
@@ -160,6 +162,7 @@ spec:
             `}}
 
 
+        {{- if .Values.prometheus.rules.migrations.enabled }}
         - alert: PendingMigrations
           labels:
             severity: critical
@@ -170,6 +173,7 @@ spec:
             summary: Pending database migrations
             message: authentik instance {{ $labels.instance }} has pending database migrations
             `}}
+        {{- end }}
 
         - alert: FailedSystemTasks
           labels:

--- a/charts/authentik/values.yaml
+++ b/charts/authentik/values.yaml
@@ -1074,6 +1074,13 @@ geoip:
 prometheus:
   rules:
     enabled: false
+    migrations:
+      # -- Emit the migration recording rules and the `PendingMigrations` alert. Off by default:
+      # the default deployment applies migrations during startup, before metrics are served, so
+      # `django_migrations_unapplied_total` is never exported and the alert can never fire. Enable
+      # it if you run migrations as a separate step, where authentik can serve against a database
+      # whose migrations have not been applied yet.
+      enabled: false
     # -- PrometheusRule namespace
     namespace: ""
     # -- PrometheusRule selector


### PR DESCRIPTION
The chart ships a `PendingMigrations` alert at `severity: critical`, plus two recording rules in the *authentik Aggregate migrations* group, all keyed on `django_migrations_unapplied_total`. **The default authentik deployment never exports that metric**, so on a stock install those rules are silent by construction.

This is [goauthentik/authentik#9941](https://github.com/goauthentik/authentik/issues/9941), open since 2024-06. I added a [confirmation there](https://github.com/goauthentik/authentik/issues/9941#issuecomment-5607517287) reproducing it on 2026.8.1 via this chart.

## Why gate rather than make the metric work

Three things must be true for the metric to appear, and none of them is. Traced through the source at `version/2026.8.1`:

1. `django-prometheus` only exports it when `PROMETHEUS_EXPORT_MIGRATIONS` is set (`DjangoPrometheusConfig.ready()`), and authentik does not set it.
2. Even set, it would not surface. `preload_app = True` loads Django's app registry — and so `ExportMigrations()` — in the gunicorn **master**, while `post_fork` only installs `MultiProcessValue` **after** the fork. The gauge lands in the master's plain in-process storage, which the multiprocess collector never reads. This is the part the issue reporter flagged as unexplained in 2024.
3. It would measure nothing anyway. `run_migrations()` runs at module level in `lifecycle/gunicorn.conf.py`, so migrations are already applied before anything observes them — the gauge would read **0 on every successful boot**.

Point 3 is the reason for gating instead of fixing. `PendingMigrations` is an alert for deployments where migrations are a **separate step** and the app can serve against an un-migrated database. That setup is real and those users are exactly who the alert was written for — so the rules stay, behind an opt-in.

## The change

One new value, `prometheus.rules.migrations.enabled`, defaulting to `false`, gating **both** the alert and the recording-rule group — the latter reads the same dead metric, so gating only the alert would leave it behind.

**Defaulting to `false` cannot regress anyone**, because the rules it disables cannot currently fire.

## Verified

Rendered three ways with `helm template`:

| values | result |
|---|---|
| defaults | no `PrometheusRule` (unchanged — `prometheus.rules.enabled` is already `false`) |
| `prometheus.rules.enabled=true` | rule renders without the migrations group and without `PendingMigrations`; the other 3 alerts and 4 recording groups intact |
| both `enabled=true` | **parsed objects identical to `main`** — 10 objects, all 6 groups, all 4 alerts. The only textual delta is 3 blank lines absorbed by `{{-` chomping |

That third case is the one that matters: the gate is purely additive for anyone who opts in.

Also run: `helm lint` clean with the gate both off and on; `yamllint -c .github/configs/lintconf.yaml` clean on `values.yaml` and `Chart.yaml`; `./scripts/helm-docs.sh` regenerated `README.md` (one row added) and is idempotent on a repeat run. No chart version bump — `check-version-increment` is `false` and the chart version tracks `appVersion` on release bumps.

## Happy to change the approach

If you would rather simply **delete** these rules than carry a flag for them, say so and I will amend — I chose the flag only to preserve the split-migration-step use case, and it is your call which is the better trade.